### PR TITLE
feat: add AWS ECR support for helm chart distribution

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,15 +3,18 @@
 
 # action-helm-distribute
 
-A GitHub Action that copies Helm charts between GCP Artifact Registry instances. It simplifies the distribution of Helm charts across different regions or projects.
+A GitHub Action that copies Helm charts between container registries. It simplifies the distribution of Helm charts across different cloud providers, regions, or projects.
 
 ## Features
 
-- Copy Helm charts between GCP Artifact Registry instances
-- Workload Identity Federation support for secure authentication
-- Cross-region and cross-project chart distribution
+- Copy Helm charts between GCP Artifact Registry and AWS ECR
+- Support for GCP Workload Identity Federation and AWS OIDC authentication
+- Cross-cloud, cross-region, and cross-project chart distribution
+- Supports GCP → GCP, GCP → AWS, AWS → GCP, and AWS → AWS transfers
 
 ## Quick Start
+
+### GCP to GCP
 
 ```yaml
 - name: Distribute Helm chart
@@ -31,6 +34,22 @@ A GitHub Action that copies Helm charts between GCP Artifact Registry instances.
     chart_version: 1.0.0
 ```
 
+### AWS to AWS
+
+```yaml
+- name: Distribute Helm chart
+  uses: martoc/action-helm-distribute@v1
+  with:
+    source_registry: aws
+    source_aws_role_arn: ${{ secrets.SOURCE_AWS_ROLE_ARN }}
+    source_region: us-east-1
+    target_registry: aws
+    target_aws_role_arn: ${{ secrets.TARGET_AWS_ROLE_ARN }}
+    target_region: eu-west-1
+    chart_name: namespace/chart
+    chart_version: 1.0.0
+```
+
 ## Documentation
 
 - [Usage Guide](./docs/USAGE.md) - Detailed usage instructions and examples
@@ -40,16 +59,18 @@ A GitHub Action that copies Helm charts between GCP Artifact Registry instances.
 
 | Input | Description | Required |
 |-------|-------------|----------|
-| `source_registry` | Source registry (e.g., `gcp`) | Yes |
-| `source_workload_identity_provider` | Source Workload Identity Provider | No |
-| `source_service_account` | Source Service Account | No |
-| `source_region` | Source region | No |
+| `source_registry` | Source registry (`gcp` or `aws`) | Yes |
+| `source_workload_identity_provider` | Source GCP Workload Identity Provider | No |
+| `source_service_account` | Source GCP Service Account | No |
+| `source_region` | Source region (GCP or AWS) | No |
 | `source_gcp_project_id` | Source GCP Project ID | No |
-| `target_registry` | Target registry (e.g., `gcp`) | Yes |
-| `target_workload_identity_provider` | Target Workload Identity Provider | No |
-| `target_service_account` | Target Service Account | No |
-| `target_region` | Target region | No |
+| `source_aws_role_arn` | Source AWS IAM Role ARN for OIDC authentication | No |
+| `target_registry` | Target registry (`gcp` or `aws`) | Yes |
+| `target_workload_identity_provider` | Target GCP Workload Identity Provider | No |
+| `target_service_account` | Target GCP Service Account | No |
+| `target_region` | Target region (GCP or AWS) | No |
 | `target_gcp_project_id` | Target GCP Project ID | No |
+| `target_aws_role_arn` | Target AWS IAM Role ARN for OIDC authentication | No |
 | `chart_name` | Helm chart in format `namespace/chart` | Yes |
 | `chart_version` | Helm chart version | Yes |
 

--- a/action.yml
+++ b/action.yml
@@ -15,11 +15,16 @@ inputs:
     required: false
   source_region:
     description: |
-      Region to push the helm to.
-      Valid values: Google Cloud.
+      Region to pull the helm chart from.
+      Valid values: Google Cloud or AWS regions.
     required: false
+    default: ""
   source_gcp_project_id:
     description: "Google Cloud Project ID"
+    required: false
+    default: ""
+  source_aws_role_arn:
+    description: "AWS IAM Role ARN for OIDC authentication"
     required: false
     default: ""
   target_registry:
@@ -33,12 +38,18 @@ inputs:
     required: false
   target_region:
     description: |
-      Region to push the container to.
+      Region to push the helm chart to.
       Valid values: Google Cloud or AWS regions.
     required: false
+    default: ""
   target_gcp_project_id:
     description: "Google Cloud Project ID"
     required: false
+    default: ""
+  target_aws_role_arn:
+    description: "AWS IAM Role ARN for OIDC authentication"
+    required: false
+    default: ""
   chart_name:
     description: "Helm chart in the format namespace/chart"
     required: true
@@ -51,27 +62,65 @@ runs:
     - name: Set up Cloud SDK
       uses: google-github-actions/setup-gcloud@v2
       with:
-        chart_name: 499.0.0
+        version: 499.0.0
       if: ${{ inputs.source_registry == 'gcp' || inputs.target_registry == 'gcp' }}
     - uses: google-github-actions/auth@v2
       with:
         workload_identity_provider: ${{ inputs.source_workload_identity_provider }}
         service_account: ${{ inputs.source_service_account }}
       if: ${{ inputs.source_registry == 'gcp' }}
-    - name: Pull image from source
+    - name: Pull chart from GCP source
       shell: bash
       run: |
         gcloud auth print-access-token | helm registry login -u oauth2accesstoken --password-stdin https://${{ inputs.source_region }}-docker.pkg.dev
         helm pull oci://${{ inputs.source_region }}-docker.pkg.dev/${{ inputs.source_gcp_project_id }}/${{ inputs.chart_name }} --version "${{ inputs.chart_version }}"
       if: ${{ inputs.source_registry == 'gcp' }}
+    - name: Configure AWS credentials for source
+      uses: aws-actions/configure-aws-credentials@v4
+      with:
+        role-to-assume: ${{ inputs.source_aws_role_arn }}
+        aws-region: ${{ inputs.source_region }}
+      if: ${{ inputs.source_registry == 'aws' }}
+    - name: Pull chart from AWS ECR source
+      shell: bash
+      run: |
+        SOURCE_AWS_ACCOUNT_ID=$(echo "${{ inputs.source_aws_role_arn }}" | cut -d':' -f5)
+        if [[ -z "${SOURCE_AWS_ACCOUNT_ID}" ]]; then
+          echo "Error: Failed to extract AWS account ID from source_aws_role_arn ('${{ inputs.source_aws_role_arn }}')." >&2
+          echo "Please ensure it is a valid IAM role ARN, e.g., arn:aws:iam::<account-id>:role/<role-name>." >&2
+          exit 1
+        fi
+        aws ecr get-login-password --region ${{ inputs.source_region }} | \
+          helm registry login --username AWS --password-stdin "${SOURCE_AWS_ACCOUNT_ID}.dkr.ecr.${{ inputs.source_region }}.amazonaws.com"
+        helm pull "oci://${SOURCE_AWS_ACCOUNT_ID}.dkr.ecr.${{ inputs.source_region }}.amazonaws.com/${{ inputs.chart_name }}" --version "${{ inputs.chart_version }}"
+      if: ${{ inputs.source_registry == 'aws' }}
     - uses: google-github-actions/auth@v2
       with:
         workload_identity_provider: ${{ inputs.target_workload_identity_provider }}
         service_account: ${{ inputs.target_service_account }}
       if: ${{ inputs.target_registry == 'gcp' }}
-    - name: Push image to target
+    - name: Push chart to GCP target
       shell: bash
       run: |
         gcloud auth print-access-token | helm registry login -u oauth2accesstoken --password-stdin https://${{ inputs.target_region }}-docker.pkg.dev
         helm push $(basename ${{ inputs.chart_name }}-${{ inputs.chart_version }}.tgz) oci://${{ inputs.target_region }}-docker.pkg.dev/${{ inputs.target_gcp_project_id }}/$(dirname ${{ inputs.chart_name }})
       if: ${{ inputs.target_registry == 'gcp' }}
+    - name: Configure AWS credentials for target
+      uses: aws-actions/configure-aws-credentials@v4
+      with:
+        role-to-assume: ${{ inputs.target_aws_role_arn }}
+        aws-region: ${{ inputs.target_region }}
+      if: ${{ inputs.target_registry == 'aws' }}
+    - name: Push chart to AWS ECR target
+      shell: bash
+      run: |
+        TARGET_AWS_ACCOUNT_ID=$(echo "${{ inputs.target_aws_role_arn }}" | cut -d':' -f5)
+        if [[ -z "${TARGET_AWS_ACCOUNT_ID}" ]]; then
+          echo "Error: Failed to extract AWS account ID from target_aws_role_arn ('${{ inputs.target_aws_role_arn }}')." >&2
+          echo "Please ensure it is a valid IAM role ARN, e.g., arn:aws:iam::<account-id>:role/<role-name>." >&2
+          exit 1
+        fi
+        aws ecr get-login-password --region ${{ inputs.target_region }} | \
+          helm registry login --username AWS --password-stdin "${TARGET_AWS_ACCOUNT_ID}.dkr.ecr.${{ inputs.target_region }}.amazonaws.com"
+        helm push $(basename ${{ inputs.chart_name }}-${{ inputs.chart_version }}.tgz) "oci://${TARGET_AWS_ACCOUNT_ID}.dkr.ecr.${{ inputs.target_region }}.amazonaws.com/$(dirname ${{ inputs.chart_name }})"
+      if: ${{ inputs.target_registry == 'aws' }}

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -1,53 +1,179 @@
 # Usage
 
-## Distribute a Helm Image
+## Distribute a Helm Chart
 
-This GitHub Action copies a Helm image to multiple registries.
+This GitHub Action copies a Helm chart between container registries. It supports GCP Artifact Registry and AWS ECR.
+
+## Supported Registry Combinations
+
+- GCP → GCP
+- GCP → AWS
+- AWS → GCP
+- AWS → AWS
 
 ## Inputs
 
-| Name                                | Description                                                                 | Required | Default |
-| ----------------------------------- | --------------------------------------------------------------------------- | -------- | ------- |
-| `source_registry`                   | Source registry                                                             | true     |         |
-| `source_workload_identity_provider` | Workload Identity Provider                                                  | false    |         |
-| `source_service_account`            | Service Account                                                             | false    |         |
-| `source_region`                     | Region to pull the Helm chart from. Valid values: Google Cloud              | false    |         |
-| `source_gcp_project_id`             | Google Cloud Project ID                                                     | false    | ""      |
-| `target_registry`                   | Target registry                                                             | true     |         |
-| `target_workload_identity_provider` | Workload Identity Provider                                                  | false    |         |
-| `target_service_account`            | Service Account                                                             | false    |         |
-| `target_region`                     | Region to push the Helm chart to. Valid values: Google Cloud or AWS regions | false    |         |
-| `target_gcp_project_id`             | Google Cloud Project ID                                                     | false    |         |
-| `helm_chart`                        | Helm chart in the format `namespace/chart`                                  | true     |         |
-| `helm_chart_version`                | Helm chart version                                                          | true     |         |
+| Name                                | Description                                                                      | Required | Default |
+| ----------------------------------- | -------------------------------------------------------------------------------- | -------- | ------- |
+| `source_registry`                   | Source registry (`gcp` or `aws`)                                                 | true     |         |
+| `source_workload_identity_provider` | GCP Workload Identity Provider for source                                        | false    |         |
+| `source_service_account`            | GCP Service Account for source                                                   | false    |         |
+| `source_region`                     | Region to pull the Helm chart from. Valid values: Google Cloud or AWS regions    | false    | ""      |
+| `source_gcp_project_id`             | Google Cloud Project ID for source                                               | false    | ""      |
+| `source_aws_role_arn`               | AWS IAM Role ARN for OIDC authentication (source)                                | false    | ""      |
+| `target_registry`                   | Target registry (`gcp` or `aws`)                                                 | true     |         |
+| `target_workload_identity_provider` | GCP Workload Identity Provider for target                                        | false    |         |
+| `target_service_account`            | GCP Service Account for target                                                   | false    |         |
+| `target_region`                     | Region to push the Helm chart to. Valid values: Google Cloud or AWS regions      | false    | ""      |
+| `target_gcp_project_id`             | Google Cloud Project ID for target                                               | false    | ""      |
+| `target_aws_role_arn`               | AWS IAM Role ARN for OIDC authentication (target)                                | false    | ""      |
+| `chart_name`                        | Helm chart in the format `namespace/chart`                                       | true     |         |
+| `chart_version`                     | Helm chart version                                                               | true     |         |
 
-## Usage
+## Examples
+
+### GCP to GCP
 
 ```yaml
-name: Distribute Helm Image
+name: Distribute Helm Chart (GCP to GCP)
 
 on: [push]
 
 jobs:
-    distribute:
-        runs-on: ubuntu-latest
-        steps:
-            - name: Checkout code
-              uses: actions/checkout@v2
+  distribute:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
 
-            - name: Distribute helm image
-              uses: martoc/action-helm-distribute@v1
-              with:
-                  source_registry: "gcp"
-                  source_workload_identity_provider: "projects/PROJECT_NUMBER/locations/global/workloadIdentityPools/POOL_ID/providers/PROVIDER_ID"
-                  source_service_account: "source-service-account@project-id.iam.gserviceaccount.com"
-                  source_region: "us-central1"
-                  source_gcp_project_id: "source-project-id"
-                  target_registry: "gcp"
-                  target_workload_identity_provider: "projects/PROJECT_NUMBER/locations/global/workloadIdentityPools/POOL_ID/providers/PROVIDER_ID"
-                  target_service_account: "target-service-account@project-id.iam.gserviceaccount.com"
-                  target_region: "europe-west1"
-                  target_gcp_project_id: "target-project-id"
-                  helm_chart: "namespace/chart"
-                  helm_chart_version: "1.0.0"
+      - name: Distribute Helm chart
+        uses: martoc/action-helm-distribute@v1
+        with:
+          source_registry: gcp
+          source_workload_identity_provider: projects/PROJECT_NUMBER/locations/global/workloadIdentityPools/POOL_ID/providers/PROVIDER_ID
+          source_service_account: source-service-account@project-id.iam.gserviceaccount.com
+          source_region: us-central1
+          source_gcp_project_id: source-project-id
+          target_registry: gcp
+          target_workload_identity_provider: projects/PROJECT_NUMBER/locations/global/workloadIdentityPools/POOL_ID/providers/PROVIDER_ID
+          target_service_account: target-service-account@project-id.iam.gserviceaccount.com
+          target_region: europe-west1
+          target_gcp_project_id: target-project-id
+          chart_name: namespace/chart
+          chart_version: 1.0.0
 ```
+
+### AWS to AWS
+
+```yaml
+name: Distribute Helm Chart (AWS to AWS)
+
+on: [push]
+
+jobs:
+  distribute:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Distribute Helm chart
+        uses: martoc/action-helm-distribute@v1
+        with:
+          source_registry: aws
+          source_aws_role_arn: arn:aws:iam::123456789012:role/source-role
+          source_region: us-east-1
+          target_registry: aws
+          target_aws_role_arn: arn:aws:iam::987654321098:role/target-role
+          target_region: eu-west-1
+          chart_name: namespace/chart
+          chart_version: 1.0.0
+```
+
+### GCP to AWS
+
+```yaml
+name: Distribute Helm Chart (GCP to AWS)
+
+on: [push]
+
+jobs:
+  distribute:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Distribute Helm chart
+        uses: martoc/action-helm-distribute@v1
+        with:
+          source_registry: gcp
+          source_workload_identity_provider: projects/PROJECT_NUMBER/locations/global/workloadIdentityPools/POOL_ID/providers/PROVIDER_ID
+          source_service_account: source-service-account@project-id.iam.gserviceaccount.com
+          source_region: us-central1
+          source_gcp_project_id: source-project-id
+          target_registry: aws
+          target_aws_role_arn: arn:aws:iam::123456789012:role/target-role
+          target_region: eu-west-1
+          chart_name: namespace/chart
+          chart_version: 1.0.0
+```
+
+### AWS to GCP
+
+```yaml
+name: Distribute Helm Chart (AWS to GCP)
+
+on: [push]
+
+jobs:
+  distribute:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Distribute Helm chart
+        uses: martoc/action-helm-distribute@v1
+        with:
+          source_registry: aws
+          source_aws_role_arn: arn:aws:iam::123456789012:role/source-role
+          source_region: us-east-1
+          target_registry: gcp
+          target_workload_identity_provider: projects/PROJECT_NUMBER/locations/global/workloadIdentityPools/POOL_ID/providers/PROVIDER_ID
+          target_service_account: target-service-account@project-id.iam.gserviceaccount.com
+          target_region: europe-west1
+          target_gcp_project_id: target-project-id
+          chart_name: namespace/chart
+          chart_version: 1.0.0
+```
+
+## Authentication
+
+### GCP Authentication
+
+For GCP, the action uses Workload Identity Federation. You need to:
+
+1. Set up a Workload Identity Pool and Provider in your GCP project
+2. Grant the GitHub Actions service account access to Artifact Registry
+3. Provide the `workload_identity_provider` and `service_account` inputs
+
+### AWS Authentication
+
+For AWS, the action uses OIDC authentication. You need to:
+
+1. Set up an OIDC identity provider in AWS IAM for GitHub Actions
+2. Create an IAM role with ECR permissions and trust policy for GitHub Actions
+3. Provide the `aws_role_arn` input with the role ARN


### PR DESCRIPTION
## Summary

- Add support for distributing Helm charts to and from AWS ECR registries
- Support all registry combinations: GCP → GCP, GCP → AWS, AWS → GCP, AWS → AWS
- Add comprehensive documentation with examples for all combinations

## Changes

### action.yml
- Add `source_aws_role_arn` and `target_aws_role_arn` input parameters
- Add AWS credentials configuration steps using `aws-actions/configure-aws-credentials@v4`
- Add helm pull/push steps for AWS ECR using OIDC authentication
- Extract AWS account ID from role ARN with validation

### Documentation
- Update README.md with AWS examples and updated inputs table
- Update docs/USAGE.md with examples for all four registry combinations
- Add Authentication section explaining GCP WIF and AWS OIDC setup

## Test plan

- [ ] Test GCP to GCP distribution (existing functionality)
- [ ] Test AWS to AWS distribution
- [ ] Test GCP to AWS distribution
- [ ] Test AWS to GCP distribution